### PR TITLE
Add Dockerfile build to AWS Lambda Autoscaler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Use AWS Lambda Python 3.13 runtime base image
+FROM public.ecr.aws/lambda/python:3.13
+
+# Copy requirements file
+COPY aws_requirements.txt ${LAMBDA_TASK_ROOT}/
+
+# Install dependencies
+RUN pip install --no-cache-dir -r aws_requirements.txt
+
+# Copy application code
+COPY stackguardian_autoscaler.py ${LAMBDA_TASK_ROOT}/
+COPY aws_service.py ${LAMBDA_TASK_ROOT}/
+COPY lambda.py ${LAMBDA_TASK_ROOT}/
+
+# Set the CMD to your handler
+CMD ["lambda.lambda_handler"]

--- a/Dockerfile.pyinstaller
+++ b/Dockerfile.pyinstaller
@@ -1,0 +1,94 @@
+# Multi-stage build for AWS Lambda with PyInstaller bundling
+# Stage 1: Build stage with PyInstaller - use same base as Lambda runtime
+FROM public.ecr.aws/lambda/python:3.13 as builder
+
+# Install system dependencies for PyInstaller
+RUN microdnf update -y && microdnf install -y \
+    gcc \
+    gcc-c++ \
+    binutils \
+    glibc-devel \
+    && microdnf clean all
+
+# Install PyInstaller and build dependencies
+RUN pip install --no-cache-dir \
+    pyinstaller>=6.0.0 \
+    wheel
+
+# Set working directory
+WORKDIR /build
+
+# Copy requirements and install dependencies
+COPY aws_requirements.txt .
+RUN pip install --no-cache-dir -r aws_requirements.txt
+
+# Copy source code
+COPY stackguardian_autoscaler.py .
+COPY aws_service.py .
+COPY lambda.py .
+# COPY lambda_wrapper.py .
+
+# Build the executable with PyInstaller using inline parameters
+RUN pyinstaller \
+    --clean \
+    --onefile \
+    --strip \
+    --name lambda_handler \
+    --console \
+    --hidden-import stackguardian_autoscaler \
+    --hidden-import aws_service \
+    --hidden-import boto3 \
+    --hidden-import botocore \
+    --hidden-import certifi \
+    --hidden-import charset_normalizer \
+    --hidden-import idna \
+    --hidden-import jmespath \
+    --hidden-import mypy_boto3 \
+    --hidden-import mypy_boto3_autoscaling \
+    --hidden-import mypy_boto3_s3 \
+    --hidden-import python_dateutil \
+    --hidden-import requests \
+    --hidden-import s3transfer \
+    --hidden-import six \
+    --hidden-import typing_extensions \
+    --hidden-import urllib3 \
+    --hidden-import json \
+    --hidden-import datetime \
+    --hidden-import logging \
+    --hidden-import os \
+    --hidden-import typing \
+    --hidden-import abc \
+    lambda.py
+
+# Stage 2: AWS Lambda runtime
+FROM public.ecr.aws/lambda/python:3.13
+
+# Copy the compiled executable and wrapper
+COPY lambda_wrapper.py ${LAMBDA_TASK_ROOT}/
+COPY --from=builder /build/dist/lambda_handler ${LAMBDA_TASK_ROOT}/
+
+# Make executable
+RUN chmod +x ${LAMBDA_TASK_ROOT}/lambda_handler
+
+# Security cleanup
+RUN find ${LAMBDA_TASK_ROOT} -type f \( \
+    -name "*.py" -o \
+    -name "*.pyx" -o \
+    -name "*.pxd" -o \
+    -name "*.c" -o \
+    -name "*.h" -o \
+    -name "*.md" -o \
+    -name "*.txt" -o \
+    -name "*.rst" -o \
+    -name "LICENSE*" -o \
+    -name "NOTICE*" -o \
+    -name "README*" -o \
+    -name "CHANGELOG*" \
+    \) ! -name "lambda_wrapper.py" -delete 2>/dev/null || true
+
+# Set restrictive permissions
+RUN chmod 755 ${LAMBDA_TASK_ROOT}/lambda_handler && \
+    chmod 644 ${LAMBDA_TASK_ROOT}/lambda_wrapper.py
+
+# Use the wrapper as the handler
+CMD ["lambda_wrapper.lambda_handler"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+# Makefile for building and pushing Docker images for Lambda
+
+# Default version - can be overridden via command line: make dash VERSION=1.2.3
+VERSION ?= $(shell git describe --tags --always --dirty)
+
+DASH_ACCOUNT_ID = 790543352839
+PROD_ACCOUNT_ID =
+
+# Registry and image configuration
+REGISTRY = $(ACCOUNT_ID).dkr.ecr.eu-central-1.amazonaws.com
+IMAGE_NAME = private-runner/autoscaler
+FULL_IMAGE = $(REGISTRY)/$(IMAGE_NAME)
+
+# Docker build configuration
+PLATFORM = linux/arm64
+DOCKERFILE = Dockerfile.pyinstaller
+DOCKER_BUILD_ARGS = --push --pull --platform $(PLATFORM) --provenance=false
+
+# AWS profiles
+DASH_PROFILE = default
+PROD_PROFILE = sg-prod
+
+# Default values for dynamic build
+PROFILE ?=
+ACCOUNT_ID ?=
+
+.PHONY: help version login build dash prod
+
+help: ## Show this help message
+	@echo 'Usage: make <target>'
+	@echo ''
+	@echo 'Targets:'
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+version: ## Show current version
+	@echo $(VERSION)
+
+login: ## Login to ECR using PROFILE variable
+	@echo "Logging into ECR using profile: $(PROFILE)..."
+	@aws --profile $(PROFILE) ecr get-login-password --region eu-central-1 \
+		| docker login --username AWS --password-stdin $(REGISTRY)
+
+build: login ## Build and push Docker image using VERSION variable
+	@echo "Building and pushing image: $(FULL_IMAGE):$(VERSION)"
+	@docker buildx build \
+		-f $(DOCKERFILE) $(DOCKER_BUILD_ARGS) \
+		-t $(FULL_IMAGE):$(VERSION) .
+	@echo "Build completed: $(FULL_IMAGE):$(VERSION)"
+
+dash: PROFILE=$(DASH_PROFILE)
+dash: ACCOUNT_ID=$(DASH_ACCOUNT_ID)
+dash: build ## Build and push Docker image for Dash environment with compiled and tagged code
+
+dash-raw: PROFILE=$(DASH_PROFILE)
+dash-raw: ACCOUNT_ID=$(DASH_ACCOUNT_ID)
+dash-raw: DOCKERFILE=Dockerfile
+dash-raw: build ## Build and push Docker image for Dash environment with source Python code
+
+dash-lts: PROFILE=$(DASH_PROFILE)
+dash-lts: ACCOUNT_ID=$(DASH_ACCOUNT_ID)
+dash-lts: VERSION="latest"
+dash-lts: build ## Build and push Docker image for Dash environment with compiled and latest tag
+
+prod: PROFILE=$(PROD_PROFILE)
+prod: ACCOUNT_ID=$(PROD_ACCOUNT_ID)
+prod: build ## Build and push Docker image for Prod environment
+
+## TODO(adis.halilovic@stackguardian.io): Clean built images
+# clean: ## Clean up local Docker images
+# 	@echo "Cleaning up local images..."
+# 	@docker image prune -f
+# 	@docker builder prune -f

--- a/lambda.py
+++ b/lambda.py
@@ -1,5 +1,12 @@
+import json
+import sys
+import logging
 from stackguardian_autoscaler import StackGuardianAutoscaler
 from aws_service import AwsService
+
+# Setup logger
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 
 def lambda_handler(event, context):
@@ -14,7 +21,8 @@ def lambda_handler(event, context):
         dict: A response object containing the status code and message.
     """
     # Log the incoming event for debugging
-    print("Received event:", event)
+    # print("Received event:", event)
+    # logger.info(f"Received event: {event}")
 
     # Process the event (this is a placeholder for your actual logic)
     autoscaler = StackGuardianAutoscaler(cloud_service=AwsService())
@@ -27,3 +35,19 @@ def lambda_handler(event, context):
         response = {"statusCode": 500, "body": str(e)}
 
     return response
+
+
+if __name__ == "__main__":
+    # Read event and context from stdin when executed as binary
+    try:
+        input_data = json.loads(sys.stdin.read())
+        event = input_data.get("event", {})
+        context = input_data.get("context", "")
+
+        result = lambda_handler(event, context)
+        sys.exit(0 if result["statusCode"] == 200 else 1)
+    except Exception as e:
+        print(f"Exception in main: {e}", file=sys.stderr)
+        error_response = {"statusCode": 500, "body": str(e)}
+        print(json.dumps(error_response))
+        sys.exit(1)

--- a/lambda_wrapper.py
+++ b/lambda_wrapper.py
@@ -1,0 +1,79 @@
+import subprocess
+import json
+import os
+import logging
+import traceback
+
+# Configure logging
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def lambda_handler(event, context):
+    try:
+        # Determine binary path
+        task_root = os.environ.get("LAMBDA_TASK_ROOT", "/var/task")
+        binary_path = os.path.join(task_root, "lambda_handler")
+
+        # Validate binary existence and executability
+        if not os.path.exists(binary_path):
+            logger.error(f"Binary not found at {binary_path}")
+            return {
+                "statusCode": 404,
+                "body": json.dumps(
+                    {"error": "Binary not found", "path": binary_path}
+                ),
+            }
+
+        if not os.access(binary_path, os.X_OK):
+            logger.error(f"Binary not executable at {binary_path}")
+            return {
+                "statusCode": 403,
+                "body": json.dumps(
+                    {"error": "Binary not executable", "path": binary_path}
+                ),
+            }
+
+        # Prepare input for subprocess
+        input_data = json.dumps({"event": event, "context": str(context)})
+
+        # Run subprocess with enhanced error handling
+        try:
+            result = subprocess.run(
+                [binary_path],
+                input=input_data,
+                text=True,
+                capture_output=True,
+                env=os.environ.copy(),
+                timeout=30,  # Add timeout to prevent hanging
+            )
+        except subprocess.TimeoutExpired:
+            logger.error("Binary execution timed out")
+            return {
+                "statusCode": 504,
+                "body": json.dumps({"error": "Execution timed out"}),
+            }
+
+        # Log stderr if not empty
+        if result.stderr:
+            print(result.stderr)
+
+        # Log stdout if not empty
+        if result.stdout:
+            print(result.stdout)
+
+    except Exception as e:
+        # Catch-all error handling
+        logger.error(f"Unexpected error: {str(e)}")
+        logger.error(traceback.format_exc())
+
+        return {
+            "statusCode": 500,
+            "body": json.dumps(
+                {
+                    "error": "Unexpected error",
+                    "details": str(e),
+                    "trace": traceback.format_exc(),
+                }
+            ),
+        }

--- a/stackguardian_autoscaler.py
+++ b/stackguardian_autoscaler.py
@@ -84,13 +84,13 @@ class StackGuardianAutoscaler:
         self.SG_BASE_URI = os.getenv("SG_BASE_URI")
         self.SG_API_KEY = os.getenv("SG_API_KEY")
 
-        self.SCALE_IN_THRESHOLD = int(os.getenv("SCALE_IN_THRESHOLD"))
-        self.SCALE_IN_STEP = int(os.getenv("SCALE_IN_STEP"))
+        self.SCALE_IN_THRESHOLD = int(os.getenv("SCALE_IN_THRESHOLD", 3))
+        self.SCALE_IN_STEP = int(os.getenv("SCALE_IN_STEP", 1))
 
-        self.SCALE_OUT_THRESHOLD = int(os.getenv("SCALE_OUT_THRESHOLD"))
-        self.SCALE_OUT_STEP = int(os.getenv("SCALE_OUT_STEP"))
+        self.SCALE_OUT_THRESHOLD = int(os.getenv("SCALE_OUT_THRESHOLD", 5))
+        self.SCALE_OUT_STEP = int(os.getenv("SCALE_OUT_STEP", 1))
 
-        self.MIN_RUNNERS = 0
+        self.MIN_RUNNERS = int(os.getenv("MIN_RUNNERS", 0))
 
         self.SG_ORG = os.getenv("SG_ORG")
         self.SG_RUNNER_GROUP = os.getenv("SG_RUNNER_GROUP")
@@ -98,10 +98,10 @@ class StackGuardianAutoscaler:
         self.cloud_service = cloud_service
 
         self.scale_in_cooldown_duration = timedelta(
-            minutes=int(os.getenv("SCALE_IN_COOLDOWN_DURATION"))
+            minutes=int(os.getenv("SCALE_IN_COOLDOWN_DURATION", 5))
         )
         self.scale_out_cooldown_duration = timedelta(
-            minutes=int(os.getenv("SCALE_OUT_COOLDOWN_DURATION"))
+            minutes=int(os.getenv("SCALE_OUT_COOLDOWN_DURATION", 5))
         )
 
         self.sg_runner_group = None


### PR DESCRIPTION
## Summary  
This PR introduces the build and deployment process for _AWS Autoscaler Lambda_ by adding a configuration for building the container image.

## Key Changes  
-  Added base `Dockerfile` and `Dockerfile.pyinstaller` for compiling _AWS Autoscaler Lambda_  
-  Implemented `Makefile` to streamline the build process  
-  Fixed loading of the environment variable `MIN_RUNNERS`  
-  Added default values for integer environment variables  

## Additional Notes  
The _AWS Autoscaler Lambda_ is compiled using `pyinstaller`. This approach is necessary because the _Lambda_ will be published on _Public ECR_. It will be used across customer organizations and must be accessible to everyone. By compiling it, we obfuscate the source code of the _Autoscaler_.

> [!NOTE]  
> If necessary, the _Source Code_ can be shared with organizations running _Autoscaler Lambda_.